### PR TITLE
adds detection of ores with block tags

### DIFF
--- a/hub_files/config.lua
+++ b/hub_files/config.lua
@@ -368,6 +368,15 @@ orenames = {
     ['appliedenergistics2:quartz_ore'] = true
 }
 
+blocktags = {
+    -- ALL BLOCKS WITH ONE OF THESE TAGS A TURTLE CONSIDERS ORE
+    --     most mods categorize ores with the forge:ores tag.
+    --     this is an easy way to detect all but a few ores,
+    --     which don't posess this exact tag (for example certus quartzfrom AE2)
+    ['forge:ores'] = true,
+    -- adds Certus Quartz and Charged Certus Quartz
+    ['forge:ores/certus_quartz'] = true
+}
 
 fuelnames = {
     -- ITEMS THE TURTLE CONSIDERS FUEL

--- a/turtle_files/actions.lua
+++ b/turtle_files/actions.lua
@@ -600,13 +600,29 @@ function dump(direction)
 end
 
 
+function checkTags(data)
+    if type(data.tags) ~= 'table' then
+        return false
+    end
+    for k,v in pairs(data.tags) do
+        if config.blocktags[k] then
+            return true
+        end
+    end
+    return false
+end
+
+
 function detect_ore(direction)
-    if config.orenames[({inspect[direction]()})[2].name] then
+    local block = ({inspect[direction]()})[2]
+    if config.orenames[block.name] then
+        return true
+    elseif checkTags(block) then
         return true
     end
     return false
 end
-   
+
 
 function scan(valid, ores)
     local checked_left  = false


### PR DESCRIPTION
Most mods have their items tagged correctlly inside with forge. By checking if the 'forge:ores' Tag is on the inspected block, we can easily detect if it is an ore, regardless of the mods installed, aslong the mods categorize their ore correctly.

I implemented it into the config, like the orenames, which provides an easy way to add more Tags. One point of note is, that a few mods  extend the Tag (see AE2 Quartz 'forge:ores/certus_quartz' versus MC Iron which has both 'forge/ores' and 'forge/ores/iron'). This is easily solvable by pattern matching the strings, but could slow down the inspect operation, so I decided against it.