### PR TITLE
Advanced Peripherals Compatibility(tested on 1.16.5)

### DIFF
--- a/hub_files/monitor.lua
+++ b/hub_files/monitor.lua
@@ -219,6 +219,15 @@ function turtle_viewer(turtle_ids)
             term.setBackgroundColor(colors.blue)
             term.setCursorPos(elements.turtle_face.x, elements.turtle_face.y + 2)
             term.write(' ')
+        elseif turtle.data.peripheral_right == 'chunky' then
+            term.setBackgroundColor(colors.white)
+            term.setCursorPos(elements.turtle_face.x, elements.turtle_face.y + 1)
+            term.write(' ')
+            term.setCursorPos(elements.turtle_face.x, elements.turtle_face.y + 3)
+            term.write(' ')
+            term.setBackgroundColor(colors.red)
+            term.setCursorPos(elements.turtle_face.x, elements.turtle_face.y + 2)
+            term.write(' ')
         end
         
         if turtle.data.peripheral_left == 'modem' then
@@ -245,6 +254,15 @@ function turtle_viewer(turtle_ids)
             term.setCursorPos(elements.turtle_face.x + 8, elements.turtle_face.y + 3)
             term.write(' ')
             term.setBackgroundColor(colors.blue)
+            term.setCursorPos(elements.turtle_face.x + 8, elements.turtle_face.y + 2)
+            term.write(' ')
+        elseif turtle.data.peripheral_left == 'chunky' then
+            term.setBackgroundColor(colors.white)
+            term.setCursorPos(elements.turtle_face.x + 8, elements.turtle_face.y + 1)
+            term.write(' ')
+            term.setCursorPos(elements.turtle_face.x + 8, elements.turtle_face.y + 3)
+            term.write(' ')
+            term.setBackgroundColor(colors.red)
             term.setCursorPos(elements.turtle_face.x + 8, elements.turtle_face.y + 2)
             term.write(' ')
         end

--- a/turtle_files/actions.lua
+++ b/turtle_files/actions.lua
@@ -550,7 +550,7 @@ function initialize(session_id, config_values)
     -- DETERMINE TURTLE TYPE
     state.peripheral_left = peripheral.getType('left')
     state.peripheral_right = peripheral.getType('right')
-    if state.peripheral_left == 'chunkLoader' or state.peripheral_right == 'chunkLoader' then
+    if state.peripheral_left == 'chunkLoader' or state.peripheral_right == 'chunkLoader' or state.peripheral_left == 'chunky' or state.peripheral_right == 'chunky' then
         state.type = 'chunky'
         for k, v in pairs(config.chunky_turtle_locations) do
             config.locations[k] = v


### PR DESCRIPTION
Hi was trying this out on 1.16.5 using advanced peripherals to and noticed  the chunky turtles were registering as mining. Took a look and noticed that "peripherals" was returning chunky and not chunkloader with advanced peripherals. So just added chunky as an alternate option when classifing turtles. Also added some new pixel art in monitor to match the chunkloader icon in advanced peripherals. unless i missed something it should work with both peripheralsplusone as well as advanced peripherals now