### PR TITLE
Better Ore Detection for Modded Ores

### DIFF
--- a/turtle_files/actions.lua
+++ b/turtle_files/actions.lua
@@ -624,11 +624,13 @@ end
 
 function detect_ore(direction)
     local block = ({inspect[direction]()})[2]
-    if config.orenames[block.name] then
+    if block == nil or block.name == nil then
+        return false
+    elseif config.orenames[block.name] then
         return true
     elseif checkTags(block) then
         return true
-    elseif block.name != nil and block.name:lower():find("ore") then  
+    elseif block.name:lower():find("ore") then  
         return true
     end
     return false

--- a/turtle_files/actions.lua
+++ b/turtle_files/actions.lua
@@ -624,7 +624,7 @@ end
 
 function detect_ore(direction)
     local block = ({inspect[direction]()})[2]
-    if config.orenames[block.name] then
+    if config.orenames[block.name] or block.name:lower():find("ore") then
         return true
     elseif checkTags(block) then
         return true

--- a/turtle_files/actions.lua
+++ b/turtle_files/actions.lua
@@ -624,9 +624,11 @@ end
 
 function detect_ore(direction)
     local block = ({inspect[direction]()})[2]
-    if config.orenames[block.name] or block.name:lower():find("ore") then
+    if config.orenames[block.name] then
         return true
     elseif checkTags(block) then
+        return true
+    elseif block.name != nil and block.name:lower():find("ore") then  
         return true
     end
     return false


### PR DESCRIPTION
Noticed that Modded ores were not being vein mined.
Added 2 more if statements to account for air blocks and for if a block has the word ore in its name.

Tested on 1.18.1 AQM2.